### PR TITLE
Tailwind CSS を導入して適用確認

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2", ">= 7.2.2.1"
+
+gem "tailwindcss-rails"
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,11 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    tailwindcss-rails (4.2.3)
+      railties (>= 7.0.0)
+      tailwindcss-ruby (~> 4.0)
+    tailwindcss-ruby (4.1.10-x86_64-darwin)
+    tailwindcss-ruby (4.1.10-x86_64-linux-gnu)
     thor (1.3.2)
     timeout (0.4.3)
     turbo-rails (2.0.16)
@@ -299,6 +304,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (>= 1.4)
   stimulus-rails
+  tailwindcss-rails
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server
+css: bin/rails tailwindcss:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,4 @@
 <h1>Lyric Garden（仮）TOPページ</h1>
 <p>ここにコンセプトやボタンなど入れる予定です</p>
+
+<h1 class="text-3xl font-bold text-blue-500 text-center">Tailwindが効いてるかテスト！</h1>

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## 概要
Tailwind CSSを導入し、今後のフロントエンド開発の基盤を整えました。

## 実施内容
- gem 'tailwindcss-rails' を追加
- `bin/rails tailwindcss:install` を実行
- `app/views/layouts/application.html.erb` にTailwindの読み込みタグを追加
- `pages#home` にテスト用のTailwindクラスを適用し、適用確認済み
- `bin/dev` にてスタイル反映を確認

## 動作確認
以下のようにブラウザでTailwindのスタイルが正しく適用されていることを確認済みです。

![Tailwind適用確認](https://i.gyazo.com/4dd529e4b73cc4969d907b005320a532.png)

## 補足
- `bin/rails s` ではスタイルが反映されないため、`bin/dev` でのサーバー起動が必要です。
- Tailwind適用の確認後、本ブランチをmainへマージ予定です。
