### PR TITLE
ナビゲーションバー追加とログアウトやログインなどボタン追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  # These methods will be available in views as well as controllers
+  helper_method :current_user, :user_signed_in?
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,11 +13,20 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+
+    <!-- Tailwind CSS -->
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+
+    <!-- Font Awesome（アイコン用） -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
+    <!-- ナビゲーションバー -->
+    <%= render "shared/navbar" %>
+
     <% flash.each do |key, value| %>
       <div class="flash <%= key %>"><%= value %></div>
     <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,0 +1,42 @@
+<header class="bg-white shadow-md">
+  <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+    <!-- ロゴ -->
+    <%= link_to "Lyric Garden", root_path, class: "text-2xl font-bold text-blue-600" %>
+
+    <!-- ナビゲーションメニュー -->
+    <div class="flex items-center space-x-4">
+      <!-- 追加箇所は if 文の上あたりがおすすめ -->
+      <p class="text-xs text-red-600">ログイン状態: <%= user_signed_in? %></p>
+      <% if user_signed_in? %>
+        <!-- ログイン時：アイコンボタンでドロップダウン -->
+        <div class="relative group inline-block">
+            <!-- ボタン -->
+            <button type="button" class="text-gray-700 text-xl flex items-center">
+                <i class="fas fa-user"></i>
+            </button>
+
+            <!-- メニュー -->
+            <div
+                class="absolute right-0 top-full mt-1 w-32 bg-white rounded-md shadow-lg
+                    opacity-0 invisible
+                    group-hover:opacity-100 group-hover:visible
+                    transition duration-150 ease-out">
+                <%= link_to "マイページ", "#", #<!-- user_path(current_user) -->
+                    class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+                <%= link_to "ログアウト",
+                    destroy_user_session_path,
+                    data: { turbo_method: :delete, turbo_confirm: "本当にログアウトしますか？" },
+                    class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
+            </div>
+        </div>
+
+      <% else %>
+        <!-- 非ログイン時：ログイン・新規登録 -->
+        <%= link_to "ログイン", new_user_session_path, class: "text-gray-700 hover:text-blue-600" %>
+        <%= link_to "新規登録", new_user_registration_path, class: "ml-2 text-gray-700 hover:text-blue-600" %>
+        <!-- 強制ログイン確認用リンク -->
+        <%= link_to "ログイン画面へ", new_user_session_path, class: "text-red-500" %>
+      <% end %>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
##  概要  
ナビゲーションバーの表示切り替えを実装しました。  
ログイン状態によって表示内容が変化するようにしました。

---

## 実装内容  
- 共通レイアウトにナビゲーションバー（`_navbar.html.erb`）を追加
- ログイン状態に応じた表示の切り替え
  - ログイン中：人アイコン → ホバーで「マイページ」「ログアウト」が表示
  - 未ログイン：右上に「ログイン」「新規登録」のリンク
- Font Awesome 読み込みエラー解消（integrity属性を削除）
- `destroy_user_session_path` が `DELETE` メソッドで動作するよう修正
- ログイン状態のテスト表示を一時的に `application.html.erb` に追加

---

##  動作確認  
- [x] ログイン時に人アイコンが表示される  
- [x] ホバー時に「マイページ」「ログアウト」が表示される  
- [x] ログアウトすると非ログイン状態の表示に切り替わる  
- [x] Font Awesome のアイコンが表示される  
- [x] Tailwind CSS が正しく反映されている

---

##  補足  
- 「マイページ」は仮リンク（`"#"`）のままです。今後の実装で差し替え予定。
- Tailwind / Font Awesome の表示確認用にテスト表示を残しています（後ほど削除予定）。
