### PR TITLE
歌詞投稿バリデーションとエラーメッセージの追加

### DIFF
--- a/app/models/lyric.rb
+++ b/app/models/lyric.rb
@@ -2,6 +2,6 @@ class Lyric < ApplicationRecord
   belongs_to :user
 
   validates :title, presence: true
-  validates :body, presence: true
-  validates :reference, length: { maximum: 5000 }
+  validates :body, presence: true, length: { maximum: 5000 }
+  validates :reference, length: { maximum: 100 }, allow_blank: true
 end

--- a/app/views/lyrics/new.html.erb
+++ b/app/views/lyrics/new.html.erb
@@ -1,5 +1,16 @@
 <h1 class="text-2xl font-bold mb-4">新しい歌詞の投稿</h1>
 
+<% if @lyric.errors.any? %>
+  <div class="mb-4 text-red-600">
+    <h2><%= pluralize(@lyric.errors.count, "エラー") %>が発生しました:</h2>
+    <ul>
+      <% @lyric.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_with(model: @lyric, local: true) do |form| %>
   <div class="mb-4">
     <%= form.label :title, "タイトル", class: "block font-semibold mb-1" %>


### PR DESCRIPTION
## 概要

歌詞投稿機能におけるバリデーションとエラーメッセージの表示対応を行いました。

## 対応内容

- `Lyric`モデルにバリデーションを追加・調整  
  - `title`: 必須
  - `body`: 必須・5000文字以内
  - `reference`: 任意・100文字以内
- フォーム画面（`lyrics/new.html.erb`）にエラーメッセージの表示処理を追加

## 確認方法

1. タイトル・本文を未入力で投稿 → それぞれのエラーメッセージが表示されることを確認
2. 本文が5000文字を超える → エラーメッセージが表示されることを確認
3. 参考作品が100文字を超える → エラーメッセージが表示されることを確認
4. 正しい入力で投稿 → 正常に保存されることを確認

## 備考

- エラーメッセージは現時点ではフォーム内に表示されます（フラッシュは未使用）
- 投稿時のUX向上のため、今後スタイル調整も検討予定
