### PR TITLE
Ransackによるキーワード検索追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "pg"
 gem "dockerfile-rails", ">= 1.7", group: :development
 gem "devise"
 gem "kaminari"
+gem "ransack"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
@@ -313,6 +317,7 @@ DEPENDENCIES
   pg
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
+  ransack
   rubocop-rails-omakase
   sprockets-rails
   sqlite3 (>= 1.4)

--- a/app/controllers/lyrics_controller.rb
+++ b/app/controllers/lyrics_controller.rb
@@ -3,7 +3,8 @@ class LyricsController < ApplicationController
   before_action :authenticate_user!, only: [ :new, :create ]
 
   def index
-    @lyrics = Lyric.includes(:user).order(created_at: :desc).page(params[:page])
+    @q = Lyric.ransack(params[:q])
+    @lyrics = @q.result.includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/models/lyric.rb
+++ b/app/models/lyric.rb
@@ -6,4 +6,21 @@ class Lyric < ApplicationRecord
   validates :reference, length: { maximum: 100 }, allow_blank: true
 
   paginates_per 10  # ← 1ページ10件に変更
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[title body reference created_at id updated_at user_id]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[user]  # :userアソシエーションを検索許可
+  end
+
+  # Ransackで「タイトル or 本文 or 参考作品」の横断検索を実現
+  ransacker :title_or_body_or_reference_cont do |parent|
+    Arel::Nodes::Grouping.new(
+      parent.table[:title].matches("%#{parent.context.params.dig(:q, :title_or_body_or_reference_cont)}%")
+      .or(parent.table[:body].matches("%#{parent.context.params.dig(:q, :title_or_body_or_reference_cont)}%"))
+      .or(parent.table[:reference].matches("%#{parent.context.params.dig(:q, :title_or_body_or_reference_cont)}%"))
+    )
+  end
 end

--- a/app/views/lyrics/index.html.erb
+++ b/app/views/lyrics/index.html.erb
@@ -1,5 +1,13 @@
 <h1 class="text-2xl font-bold mb-6 text-center">歌詞一覧</h1>
 
+<%= search_form_for @q, url: lyrics_path, method: :get do |f| %>
+  <div class="search-box">
+    <%= f.label :title_or_body_or_reference_cont, "キーワード検索" %><br>
+    <%= f.search_field :title_or_body_or_reference_cont, placeholder: "タイトル・本文・参考作品", class: "form-control" %>
+    <%= f.submit "検索", class: "btn btn-primary mt-2" %>
+  </div>
+<% end %>
+
 <div class="space-y-4">
   <% @lyrics.each do |lyric| %>
     <div class="bg-white rounded-lg shadow p-4 hover:bg-gray-50">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,16 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resources :lyrics, only: [ :new, :create, :show ]
+  # :index を追加！
+  resources :lyrics, only: [ :index, :new, :create, :show ]
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/*
+  # PWA関連
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # Defines the root path route ("/")
+  # トップページは歌詞一覧
   root "lyrics#index"
 end

--- a/環境構築メモ.md
+++ b/環境構築メモ.md
@@ -1,0 +1,57 @@
+## Fly.io デプロイ後に `db:prepare` で接続エラーが出た件の対応まとめ
+
+### 現象
+`RAILS_ENV=production bin/rails db:prepare` を実行すると、次のようなエラーが発生：
+
+ActiveRecord::ConnectionNotEstablished: connection to server on socket "/tmp/.s.PGSQL.5432" failed: No such file or directory
+
+### 原因
+- ローカル環境で `DATABASE_URL` を設定せずに `production` 環境を起動しようとしていた。
+- Fly.io 上では `DATABASE_URL` は `fly secrets` 経由で設定されているため、ローカルで `RAILS_ENV=production` を実行しても DBに接続できない。
+- さらに、ローカルの PostgreSQL が未起動 or 対象DB（例: `gotanoue`）が未作成だった。
+
+### 解決手順
+
+#### ✅ Fly.io 上で DB 準備する手順
+
+```bash
+# 1. アプリが起動していない場合、VMを再起動または再デプロイ
+fly deploy
+
+# 2. SSH で接続
+fly ssh console -a lyric-garden
+
+# 3. コンテナ内で production データベースを準備
+bin/rails db:prepare RAILS_ENV=production
+🔁 接続確認
+https://lyric-garden.fly.dev/ をブラウザで開いてアプリが表示されることを確認。
+
+📝 補足
+Fly.io の DB名は fly postgres connect -a [DB名] → \l で確認可能。
+
+DATABASE_URL は fly secrets list で確認。
+
+🧠 学び
+本番環境の DB 初期化は、Fly.io 上で行うのが原則。
+
+ローカルで RAILS_ENV=production を使うときは、DATABASE_URL の設定が必要。
+
+---
+
+## ✅ `README.md` に追記する内容（コピペ用）
+
+```markdown
+## デプロイ後の初期セットアップ（Fly.io）
+
+Fly.io 上でアプリをデプロイしたあと、本番環境用データベースの準備が必要です。
+
+```bash
+# Fly.io にSSH接続
+fly ssh console -a lyric-garden
+
+# コンテナ内でデータベースの初期化
+bin/rails db:prepare RAILS_ENV=production
+トラブルシューティング
+ActiveRecord::ConnectionNotEstablished エラーが出る場合、fly secrets list で DATABASE_URL が設定されているか確認してください。
+
+本番DBは Fly.io 上にあるため、ローカルで RAILS_ENV=production を指定すると接続エラーになります。


### PR DESCRIPTION
## 概要

- 歌詞一覧ページ（トップページ）に**キーワード検索機能**を実装しました。
    - Ransackを導入し、タイトル・本文・参考作品の3項目に部分一致で検索できます。
    - 検索フォームはナビゲーションバー下部に配置。
    - 検索語が未入力の場合は、全件リスト表示。
    - 検索結果が無い場合もページ自体は正しく表示されます。

## 変更内容

- Gemfileに`ransack`を追加し、`bundle install`
- LyricsController#indexでRansackのセットアップ
- 歌詞モデル（Lyric）にransackable_attributes/associationsを追加
- 検索フォームの実装（`app/views/lyrics/index.html.erb`）

## 補足

- 画面デザインやUIについては今後ブラッシュアップ予定です
- 他機能（タグ検索・ランキングなど）は後続タスクで対応予定

