### PR TITLE
Dockerfile修正: Fly.io の 0.0.0.0:3000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,4 @@ USER 1000:1000
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server
+web: bin/rails server -b 0.0.0.0 -p 3000
 css: bin/rails tailwindcss:watch


### PR DESCRIPTION
## DockerfileのWebサーバー待ち受けアドレスを修正

### 概要
- Fly.ioの本番環境でアプリのHealth Checkが失敗する問題を解消するため、Dockerfileの`CMD`（または`ENTRYPOINT`）を修正し、Railsサーバーが`0.0.0.0:3000`で待ち受けるように変更しました。

### 修正内容
- Dockerfileの`CMD`を
  ```dockerfile
  CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
