### PR TITLE
ナビゲーションバーのデザイン調整と歌詞一覧カードに本文冒頭を追加

### DIFF
--- a/app/views/lyrics/index.html.erb
+++ b/app/views/lyrics/index.html.erb
@@ -18,26 +18,33 @@
           <%= link_to lyric.title, lyric_path(lyric), class: "hover:underline" %>
         </h2>
 
-        <!-- タグ（仮：固定で表示） -->
+        <!-- タグ（仮：固定で表示）
         <div class="flex flex-wrap gap-1 mb-2">
-          <% ["桜", "春", "卒業"].each do |tag| %>
+          <% ["桜", "春", "卒業"].each do |tag| %> -->
             <!-- TODO: Tailwindカスタムカラーが使えるようになったらstyle属性を外してbg-brandに戻す -->
-            <span class="text-white text-xs px-2 py-0.5 rounded-full" style="background-color:#9AC94E;">
+            <!-- <span class="text-white text-xs px-2 py-0.5 rounded-full" style="background-color:#9AC94E;">
               <%= tag %>
             </span>
           <% end %>
-        </div>
+        </div> -->
 
         <!-- 投稿者と投稿日 -->
         <div class="text-xs text-gray-500 flex justify-between items-center mt-auto">
-          <span><%= lyric.user&.name || "名無し" %></span>
+          <!-- <span><%= lyric.user&.name || "名無し" %></span> -->
           <span><%= lyric.created_at.strftime("%Y/%-m/%-d") %></span>
         </div>
 
-        <!-- お気に入りボタン（仮） -->
+        <!-- 歌詞本文の冒頭20文字 -->
+        <div class="my-1 border-t border-gray-200 pt-1">
+          <div class="text-sm text-gray-700 mt-1 mb-1">
+            <%= truncate(lyric.body, length: 20) %>
+          </div>
+        </div>
+
+        <!-- お気に入りボタン（仮）
         <div class="text-right mt-2">
           <i class="fa-regular fa-star text-gray-400 hover:text-yellow-400 cursor-pointer"></i>
-        </div>
+        </div> -->
       </div>
     <% end %>
   </div>
@@ -46,5 +53,3 @@
     <%= paginate @lyrics %>
   </div>
 </div>
-<!-- これは一時的なダミー。どこでもいいので1行だけ追加してOK！ -->
-<div class="bg-brand hover:bg-brand-dark hidden"></div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,43 +1,76 @@
-<header class="bg-white shadow-md">
-  <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
-    <!-- ロゴ -->
-    <%= link_to "Lyric Garden", root_path, class: "text-2xl font-bold text-blue-600" %>
+<!-- app/views/shared/_navbar.html.erb -->
+<style>
+  .user-menu-container {
+    position: relative;
+    display: inline-block;
+  }
+  .user-menu-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+  .user-menu-dropdown {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: calc(100% + 2px);
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 6px 24px #0002;
+    min-width: 120px;
+    overflow: hidden;
+    z-index: 20;
+  }
+  .user-menu-container:hover .user-menu-dropdown,
+  .user-menu-container:focus-within .user-menu-dropdown {
+    display: block;
+  }
+</style>
 
-    <!-- ナビゲーションメニュー -->
-    <div class="flex items-center space-x-4">
-      <!-- 追加箇所は if 文の上あたりがおすすめ -->
-      <p class="text-xs text-red-600">ログイン状態: <%= user_signed_in? %></p>
+<header style="background: #AEC950;">
+  <div style="max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; padding: 18px 32px;">
+    <!-- ロゴ＋葉っぱ -->
+    <div style="display: flex; align-items: center;">
+      <%= link_to root_path, style: "display: flex; align-items: center; text-decoration: none;" do %>
+        <span style="font-size: 2.4rem; font-weight: bold; color: #fff; letter-spacing: 1px;">Lyric Garden</span>
+        <!-- 葉っぱアイコン例（SVG。好みで差し替えてOK） -->
+        <svg width="40" height="40" viewBox="0 0 24 24" fill="#fff" xmlns="http://www.w3.org/2000/svg" style="display: inline; vertical-align: middle;">
+          <path d="M17,8C8,10,5.9,16.17,3.82,21.34L5.71,22l1-2.3A4.49,4.49,0,0,0,8,20C19,20,22,3,22,3,21,5,14,5.25,9,6.25S2,11.5,2,13.5a6.22,6.22,0,0,0,1.75,3.75C7,8,17,8,17,8Z"/>
+        </svg>
+      <% end %>
+    </div>
+
+    <!-- メニュー部分 -->
+    <div style="display: flex; align-items: center; gap: 28px;">
       <% if user_signed_in? %>
-        <%= link_to "新規投稿", new_lyric_path, class: "ml-2 text-gray-700 hover:text-blue-600" %>
-
-        <!-- ログイン時：アイコンボタンでドロップダウン -->
-        <div class="relative group inline-block">
-            <!-- ボタン -->
-            <button type="button" class="text-  gray-700 text-xl flex items-center">
-                <i class="fas fa-user"></i>
-            </button>
-
-            <!-- メニュー -->
-            <div
-                class="absolute right-0 top-full mt-1 w-32 bg-white rounded-md shadow-lg
-                    opacity-0 invisible
-                    group-hover:opacity-100 group-hover:visible
-                    transition duration-150 ease-out">
-                <%= link_to "マイページ", "#", #<!-- user_path(current_user) -->
-                    class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
-                <%= link_to "ログアウト",
-                    destroy_user_session_path,
-                    data: { turbo_method: :delete, turbo_confirm: "本当にログアウトしますか？" },
-                    class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" %>
-            </div>
+        <!-- 新規投稿 -->
+        <%= link_to "新規投稿", new_lyric_path, style: "color: #fff; font-size: 1.7rem; font-weight: normal; margin-right: 16px; letter-spacing: 1px; text-decoration: none;" %>
+        
+        <!-- 通知ベル（現在非表示、復活時はコメントアウト外してOK） -->
+        <%# 
+        <div style="position: relative; margin-right: 16px;">
+          <i class="fas fa-bell" style="font-size: 2rem; color: #fff;"></i>
+          <span style="position: absolute; top: 2px; right: 1px; width: 10px; height: 10px; background: #FF7100; border-radius: 50%; display: inline-block; border: 2px solid #AEC950;"></span>
         </div>
+        %>
 
+        <!-- ユーザーアイコン＋ドロップダウン（hover&focus） -->
+        <div class="user-menu-container">
+          <button type="button" class="user-menu-btn">
+            <!-- 人アイコン（FontAwesome） -->
+            <i class="fas fa-user" style="font-size: 2.2rem; color: #fff; border: 2px solid #fff; border-radius: 10px; padding: 4px 10px;"></i>
+          </button>
+          <div class="user-menu-dropdown">
+            <!-- <%= link_to "マイページ", "#", style: "display: block; padding: 10px 18px; color: #444; text-decoration: none; font-weight: bold;" %> -->
+            <%= link_to "ログアウト", destroy_user_session_path,
+                data: { turbo_method: :delete, turbo_confirm: "本当にログアウトしますか？" },
+                style: "display: block; padding: 10px 18px; color: #444; text-decoration: none; font-weight: bold;" %>
+          </div>
+        </div>
       <% else %>
-        <!-- 非ログイン時：ログイン・新規登録 -->
-        <%= link_to "ログイン", new_user_session_path, class: "text-gray-700 hover:text-blue-600" %>
-        <%= link_to "新規登録", new_user_registration_path, class: "ml-2 text-gray-700 hover:text-blue-600" %>
-        <!-- 強制ログイン確認用リンク -->
-        <%= link_to "ログイン画面へ", new_user_session_path, class: "text-red-500" %>
+        <!-- 非ログイン時：新規登録・ログイン -->
+        <%= link_to "新規登録", new_user_registration_path, style: "color: #fff; font-size: 1.7rem; font-weight: normal; margin-right: 16px; letter-spacing: 1px; text-decoration: none;" %>
+        <%= link_to "ログイン", new_user_session_path, style: "color: #fff; font-size: 1.7rem; font-weight: normal; letter-spacing: 1px; text-decoration: none;" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- ナビゲーションバーのデザインをFigmaの画面遷移図に合わせて修正
- 歌詞一覧ページ（index）で、各歌詞カードに本文の冒頭20文字を表示するように変更

## 変更内容
- `/app/views/shared/_navbar.html.erb` のレイアウト・配色・アイコンなどを修正
- `/app/views/lyrics/index.html.erb` で歌詞本文の冒頭表示を追加
- 必要に応じてスタイル微調整・不要な要素のコメントアウト

## 動作確認
- ナビゲーションバーがログイン状態によって正しく切り替わることを確認
- 歌詞一覧ページで各カードに本文冒頭が正しく表示されることを確認
- 既存機能（検索・ページネーション等）への影響なし

