### PR TITLE
背景色の指定（緑）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,5 +14,5 @@
  *= require_self
  */
 body, html {
-  background: #fff !important;
+  background: #AEC950 !important;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+body, html {
+  background: #fff !important;
+}


### PR DESCRIPTION
## 概要

- アプリ全体の背景色を #AEC950 に統一しました
- 意図しない背景色（赤など）が表示されていた問題を解消

## 主な変更ファイル

- `app/assets/stylesheets/application.css`  
　→ bodyやhtmlタグへの背景色指定を追加
