### PR TITLE
ナビゲーションバーのスマホ対応

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,44 @@
 <!-- app/views/shared/_navbar.html.erb -->
 <style>
+  /* PCデフォルト */
+  .navbar-root {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 32px;
+    height: 80px;
+  }
+  .navbar-logo {
+    font-size: 2.4rem;
+    font-weight: bold;
+    color: #fff;
+    letter-spacing: 1px;
+    margin-right: 1px;
+  }
+  .navbar-leaf {
+    width: 60px;
+    height: 36px;
+    vertical-align: middle;
+  }
+  .navbar-link {
+    color: #fff;
+    font-size: 1.7rem;
+    font-weight: normal;
+    margin-right: 16px;
+    letter-spacing: 1px;
+    text-decoration: none;
+  }
+  .navbar-icon {
+    font-size: 2.2rem;
+    color: #fff;
+    border: 2px solid #fff;
+    border-radius: 10px;
+    padding: 4px 10px;
+    background: none;
+    margin-left: 6px;
+  }
   .user-menu-container {
     position: relative;
     display: inline-block;
@@ -8,6 +47,7 @@
     background: none;
     border: none;
     cursor: pointer;
+    padding: 0;
   }
   .user-menu-dropdown {
     display: none;
@@ -25,40 +65,54 @@
   .user-menu-container:focus-within .user-menu-dropdown {
     display: block;
   }
+  /* スマホ画面(〜600px)だけ小さく！ */
+  @media (max-width: 600px) {
+    .navbar-root {
+      max-width: 100vw;
+      padding: 0 12px;
+      height: 54px;
+    }
+    .navbar-logo {
+      font-size: 1.4rem;
+      margin-right: 4px;
+    }
+    .navbar-leaf {
+      width: 26px !important;
+      height: 18px !important;
+    }
+    .navbar-link {
+      font-size: 1.1rem;
+      margin-right: 7px;
+    }
+    .navbar-icon {
+      font-size: 1.5rem !important;
+      padding: 2px 4px !important;
+      margin-left: 2px;
+    }
+  }
 </style>
 
 <header style="background: #AEC950;">
-  <div style="max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; padding: 18px 32px;">
+  <div class="navbar-root">
     <!-- ロゴ＋葉っぱ -->
     <div style="display: flex; align-items: center;">
       <%= link_to root_path, style: "display: flex; align-items: center; text-decoration: none;" do %>
-        <span style="font-size: 2.4rem; font-weight: bold; color: #fff; letter-spacing: 1px;">Lyric Garden</span>
-        <!-- 葉っぱアイコン例（SVG。好みで差し替えてOK） -->
-        <svg width="40" height="40" viewBox="0 0 24 24" fill="#fff" xmlns="http://www.w3.org/2000/svg" style="display: inline; vertical-align: middle;">
+        <span class="navbar-logo">Lyric Garden</span>
+        <!-- 葉っぱアイコン（SVG） -->
+        <svg class="navbar-leaf" viewBox="0 0 24 24" fill="#fff">
           <path d="M17,8C8,10,5.9,16.17,3.82,21.34L5.71,22l1-2.3A4.49,4.49,0,0,0,8,20C19,20,22,3,22,3,21,5,14,5.25,9,6.25S2,11.5,2,13.5a6.22,6.22,0,0,0,1.75,3.75C7,8,17,8,17,8Z"/>
         </svg>
       <% end %>
     </div>
 
     <!-- メニュー部分 -->
-    <div style="display: flex; align-items: center; gap: 28px;">
+    <div style="display: flex; align-items: center; gap: 14px;">
       <% if user_signed_in? %>
-        <!-- 新規投稿 -->
-        <%= link_to "新規投稿", new_lyric_path, style: "color: #fff; font-size: 1.7rem; font-weight: normal; margin-right: 16px; letter-spacing: 1px; text-decoration: none;" %>
-        
-        <!-- 通知ベル（現在非表示、復活時はコメントアウト外してOK） -->
-        <%# 
-        <div style="position: relative; margin-right: 16px;">
-          <i class="fas fa-bell" style="font-size: 2rem; color: #fff;"></i>
-          <span style="position: absolute; top: 2px; right: 1px; width: 10px; height: 10px; background: #FF7100; border-radius: 50%; display: inline-block; border: 2px solid #AEC950;"></span>
-        </div>
-        %>
-
-        <!-- ユーザーアイコン＋ドロップダウン（hover&focus） -->
+        <%= link_to "新規投稿", new_lyric_path, class: "navbar-link" %>
+        <!-- ユーザーアイコン＋ドロップダウン -->
         <div class="user-menu-container">
           <button type="button" class="user-menu-btn">
-            <!-- 人アイコン（FontAwesome） -->
-            <i class="fas fa-user" style="font-size: 2.2rem; color: #fff; border: 2px solid #fff; border-radius: 10px; padding: 4px 10px;"></i>
+            <i class="fas fa-user navbar-icon"></i>
           </button>
           <div class="user-menu-dropdown">
             <!-- <%= link_to "マイページ", "#", style: "display: block; padding: 10px 18px; color: #444; text-decoration: none; font-weight: bold;" %> -->
@@ -68,9 +122,8 @@
           </div>
         </div>
       <% else %>
-        <!-- 非ログイン時：新規登録・ログイン -->
-        <%= link_to "新規登録", new_user_registration_path, style: "color: #fff; font-size: 1.7rem; font-weight: normal; margin-right: 16px; letter-spacing: 1px; text-decoration: none;" %>
-        <%= link_to "ログイン", new_user_session_path, style: "color: #fff; font-size: 1.7rem; font-weight: normal; letter-spacing: 1px; text-decoration: none;" %>
+        <%= link_to "新規登録", new_user_registration_path, class: "navbar-link" %>
+        <%= link_to "ログイン", new_user_session_path, class: "navbar-link", style: "margin-right:0;" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
## 🔄 ナビゲーションバーのレスポンシブ対応＆デザイン修正

### 概要
- ナビゲーションバー（_navbar.html.erb）を**PC・スマホ両対応のレスポンシブデザイン**に調整
  - ロゴ・葉っぱアイコン・新規投稿/ユーザーアイコン/認証メニューの横並び崩れをスマホでも自然に表示されるようCSS調整
  - 既存のデザインイメージをなるべく崩さず、サイズ感や配置だけ最適化

### 主な修正内容
- メディアクエリを用いて、600px以下の画面幅でナビゲーションバーのサイズ・余白・フォントサイズを調整
- ロゴ・葉っぱ・メニューがスマホでも横並び・バランス良く表示されるように修正
- 既存のHTML構造を大きく変えずに、PC/スマホの両方で見栄えを担保

### 動作確認内容
- [ ] PCブラウザで横幅を変えても崩れない
- [ ] スマホ実機 or DevToolsのモバイル表示でデザイン崩れがないことを確認
- [ ] 各リンク（トップ、新規投稿、ログイン、ログアウト）が正しく動作

