### PR TITLE
パスワード再設定ページを一旦非表示

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -33,9 +33,9 @@
         <%= f.submit "ログイン", class: "w-full sm:w-auto px-8 py-3 bg-[#9AC94E] text-white rounded shadow-md hover:bg-[#7AAA3D] transition font-semibold text-lg" %>
       </div>
 
-      <div class="flex flex-col sm:flex-row gap-4 justify-center mb-2">
+      <!-- タイトル<div class="flex flex-col sm:flex-row gap-4 justify-center mb-2">
         <%= link_to "パスワードをお忘れの方はこちら", new_user_password_path, class: "w-full sm:w-auto px-8 py-3 bg-[#9AC94E] text-white rounded shadow-md hover:bg-[#7AAA3D] transition font-semibold text-lg" %>
-      </div>
+      </div> -->
     <% end %>
 
     <div class="my-6 border-t border-gray-200 pt-6">


### PR DESCRIPTION
## 概要

- MVPリリースでの機能になかったパスワード再設定ページを実装していたので、一度取り除いた

---

## 変更内容

- `app/views/devise/sessions/new.html.erb` の修正（コメントアウト化）
---

## 動作確認項目

- 「パスワードお忘れの方はこちら」のボタンがなくなった