### PR TITLE
歌詞削除機能を実装

### DIFF
--- a/app/controllers/lyrics_controller.rb
+++ b/app/controllers/lyrics_controller.rb
@@ -1,8 +1,8 @@
 class LyricsController < ApplicationController
-  # new, create, edit, update のみ認証を要求
-  before_action :authenticate_user!, only: [ :new, :create, :edit, :update ]
-  before_action :set_lyric, only: [ :show, :edit, :update ]
-  before_action :correct_user, only: [ :edit, :update ]
+  # new, create, edit, update, destroy のみ認証を要求
+  before_action :authenticate_user!, only: [ :new, :create, :edit, :update, :destroy ]
+  before_action :set_lyric, only: [ :show, :edit, :update, :destroy ]
+  before_action :correct_user, only: [ :edit, :update, :destroy ]
 
   def index
     @q = Lyric.ransack(params[:q])
@@ -25,20 +25,22 @@ class LyricsController < ApplicationController
   end
 
   def show
-    # @lyric = Lyric.find(params[:id])  ← 上で共通化
   end
 
   def edit
-    # @lyric = Lyric.find(params[:id])  ← 上で共通化
   end
 
   def update
-    # @lyric = Lyric.find(params[:id])  ← 上で共通化
     if @lyric.update(lyric_params)
       redirect_to @lyric, notice: "歌詞を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @lyric.destroy
+    redirect_to lyrics_path, notice: "歌詞を削除しました"
   end
 
   private
@@ -47,10 +49,9 @@ class LyricsController < ApplicationController
     @lyric = Lyric.find(params[:id])
   end
 
-  # 投稿者だけ編集/更新できるように
   def correct_user
     unless @lyric.user_id == current_user&.id
-      redirect_to root_path, alert: "編集権限がありません。"
+      redirect_to root_path, alert: "権限がありません。"
     end
   end
 

--- a/app/views/lyrics/edit.html.erb
+++ b/app/views/lyrics/edit.html.erb
@@ -18,8 +18,6 @@
       <%= form.text_field :title, class: "border border-gray-300 rounded w-full p-2 focus:border-[#9AC94E] focus:ring-2 focus:ring-[#9AC94E] transition" %>
     </div>
 
-    <!-- タグ欄はMVP後で追加 -->
-
     <div class="mb-4">
       <%= form.label :reference, "参考作品（任意）", class: "block font-semibold mb-1" %>
       <%= form.text_field :reference, class: "border border-gray-300 rounded w-full p-2 focus:border-[#9AC94E] focus:ring-2 focus:ring-[#9AC94E] transition" %>
@@ -30,8 +28,17 @@
       <%= form.text_area :body, rows: 8, class: "border border-gray-300 rounded w-full p-2 focus:border-[#9AC94E] focus:ring-2 focus:ring-[#9AC94E] transition" %>
     </div>
 
-    <div class="flex justify-center">
+    <div class="flex justify-center mb-4">
       <%= form.submit "更新する", class: "px-8 py-2 bg-[#9AC94E] text-white rounded shadow-md hover:bg-[#7AAA3D] transition font-semibold text-lg" %>
+    </div>
+  <% end %>
+
+  <%# 投稿者のみ削除ボタン表示（セキュリティはControllerで制御済み） %>
+  <% if user_signed_in? && @lyric.user == current_user %>
+    <div class="flex justify-center mt-4">
+      <%= link_to "削除する", lyric_path(@lyric),
+          data: { turbo_method: :delete, turbo_confirm: "本当に削除してもいいですか？" },
+          class: "px-8 py-2 bg-red-500 text-white rounded shadow-md hover:bg-red-600 transition font-semibold text-lg" %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  resources :lyrics, only: [ :index, :show, :new, :create, :edit, :update ]
+  resources :lyrics, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
 
   # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 🎯概要

歌詞投稿の削除機能を実装
削除操作は投稿者のみが可能で、`edit` ページの下部に「削除する」ボタンを配置
また、削除前に確認ダイアログ（"本当に削除してもいいですか？"）が表示されるように設定



## 実装内容

- `LyricsController` に `destroy` アクションを追加
- `routes.rb` に `:destroy` を追加
- 投稿者のみ削除できるように `correct_user` を再利用
- `edit.html.erb` に削除ボタンを追加
  - ボタンは「更新する」の下に配置
  - `data: { turbo_confirm: "本当に削除してもいいですか？" }` を設定
